### PR TITLE
Refactor backend session and DB handling

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -4,16 +4,7 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET, POST, DELETE");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Datenbankverbindung
-$host = "ht7m.your-database.de";  
-$user = "jerome_tracker_w";  
-$pass = "KTMf57rhQ17d9zjd";  
-$dbname = "initiative_tracker"; 
-
-$pdo = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8mb4", $user, $pass, [
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
-]);
+require_once __DIR__ . '/backend/db_connect.php';
 
 $method = $_SERVER["REQUEST_METHOD"];
 
@@ -29,9 +20,10 @@ if ($method === "GET") {
         $query .= " WHERE fight_name = ?";
         $params[] = $fight_name;
     }
-    
+
+    $query .= " ORDER BY initiative DESC";
+
     $stmt = $pdo->prepare($query);
-    $stmt = $pdo->prepare("SELECT * FROM initiative ORDER BY initiative DESC");
     $stmt->execute($params);
     $entries = $stmt->fetchAll();
 

--- a/backend/check_sessions.php
+++ b/backend/check_sessions.php
@@ -7,11 +7,10 @@ header('Content-Type: application/json');
 
 if (isset($_SESSION['user_id'])) {
     echo json_encode([
-        'loggedIn' => true,
+        'status' => 'success',
         'username' => $_SESSION['username'] ?? null,
-        // ------> hier einfügen ------
         'role' => $_SESSION['role'] ?? 'player'
     ]);
 } else {
-    echo json_encode(['loggedIn' => false]);
+    echo json_encode(['status' => 'error']);
 }

--- a/backend/db_connect.php
+++ b/backend/db_connect.php
@@ -1,22 +1,27 @@
 <?php
-ini_set('session.cookie_path', '/'); // hilft, falls Pfad-Probleme auftreten
-session_start();
-// backend/db_connect.php
+/**
+ * Central database connection using PDO.
+ * Credentials are read from environment variables:
+ *  - DB_HOST
+ *  - DB_NAME
+ *  - DB_USER
+ *  - DB_PASS
+ */
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'initiative_tracker';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
 
-// --- Database Credentials ---
-$db_host = 'ht7m.your-database.de';
-$db_user = 'jerome_tracker'; // Or your specific database username
-$db_pass = 'h6akkvAgUC33Px3q';     // Or your specific database password
-$db_name = 'initiative_tracker'; // Your database name
+$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+];
 
-// --- Establish Connection ---
-$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
-
-// --- Check for Connection Errors ---
-// This check is crucial. If it fails, the script will stop here.
-if ($conn->connect_error) {
-    // Stop everything and report the error.
-    die("Database Connection Failed: " . $conn->connect_error);
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database connection failed']);
+    exit;
 }
-
-?>

--- a/backend/get_user_data.php
+++ b/backend/get_user_data.php
@@ -1,46 +1,19 @@
 <?php
-ini_set('session.cookie_path', '/'); // hilft, falls Pfad-Probleme auftreten
+ini_set('session.cookie_path', '/');
 session_start();
-// backend/get_user_data.php
 
-// Start the session to get the logged-in user's ID
-session_start();
-include 'db_connect.php';
-
-// Check if the user is actually logged in
-if (!isset($_SESSION['user_id'])) {
-    header('Content-Type: application/json');
-    http_response_code(401); // Unauthorized
-    echo json_encode(['status' => 'error', 'message' => 'User not logged in']);
-    exit(); // Stop the script
-}
-
-$user_id = $_SESSION['user_id'];
-
-// Prepare a SQL statement to get all parties the user is a member of
-// We use a JOIN to link the party_members table with the parties table
-$stmt = $conn->prepare("
-    SELECT p.id, p.name 
-    FROM parties p
-    JOIN party_members pm ON p.id = pm.party_id
-    WHERE pm.user_id = ?
-");
-$stmt->bind_param("i", $user_id);
-$stmt->execute();
-$result = $stmt->get_result();
-
-$parties = [];
-while ($row = $result->fetch_assoc()) {
-    $parties[] = $row;
-}
-
-// Send the data back as a JSON response
+require_once __DIR__ . '/db_connect.php';
 header('Content-Type: application/json');
-echo json_encode([
-    'status' => 'success',
-    'parties' => $parties
-]);
 
-$stmt->close();
-$conn->close();
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'User not logged in']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT p.id, p.name FROM parties p JOIN party_members pm ON p.id = pm.party_id WHERE pm.user_id = ?');
+$stmt->execute([$_SESSION['user_id']]);
+$parties = $stmt->fetchAll();
+
+echo json_encode(['status' => 'success', 'parties' => $parties]);
 ?>

--- a/backend/login.php
+++ b/backend/login.php
@@ -1,55 +1,31 @@
 <?php
-ini_set('session.cookie_path', '/'); // hilft, falls Pfad-Probleme auftreten
+ini_set('session.cookie_path', '/');
 session_start();
-// backend/login.php
 
-// session_start() MUST be the very first thing on the page
-// It tells the server to either start a new session or resume an existing one.
-session_start(); 
+require_once __DIR__ . '/db_connect.php';
 
-// 1. Include the database connection
-include 'db_connect.php';
+$username = $_POST['username'] ?? '';
+$password = $_POST['password'] ?? '';
 
-// 2. Get the data from the POST request
-$username = $_POST['username'];
-$password = $_POST['password'];
+header('Content-Type: application/json');
 
-// 3. Basic Validation
-if (empty($username) || empty($password)) {
-    die("Error: Username and password are required.");
+if ($username === '' || $password === '') {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Username and password are required']);
+    exit;
 }
 
-// 4. Prepare a statement to get the user's info from the database
-$stmt = $conn->prepare("SELECT id, username, password_hash FROM users WHERE username = ?");
-$stmt->bind_param("s", $username);
-$stmt->execute();
-$result = $stmt->get_result();
+$stmt = $pdo->prepare('SELECT id, username, password_hash, role FROM users WHERE username = ?');
+$stmt->execute([$username]);
+$user = $stmt->fetch();
 
-// 5. Check if a user with that username was found
-if ($result->num_rows === 1) {
-    $user = $result->fetch_assoc();
-
-    // 6. Verify the submitted password against the stored hash
-    // password_verify() is the secure counterpart to password_hash()
-    if (password_verify($password, $user['password_hash'])) {
-        
-        // Password is correct!
-        // 7. Store user data in the session.
-        // This is how the server "remembers" who is logged in across different pages.
-        $_SESSION['user_id'] = $row['id'];
-        $_SESSION['username'] = $row['username'];
-        $_SESSION['role']=$row['role'];
-        echo "Login successful!";
-
-    } else {
-        // Password was incorrect
-        echo "Error: Invalid username or password.";
-    }
+if ($user && password_verify($password, $user['password_hash'])) {
+    $_SESSION['user_id'] = $user['id'];
+    $_SESSION['username'] = $user['username'];
+    $_SESSION['role'] = $user['role'] ?? 'player';
+    echo json_encode(['status' => 'ok']);
 } else {
-    // No user found with that username
-    echo "Error: Invalid username or password.";
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid username or password']);
 }
-
-$stmt->close();
-$conn->close();
 ?>

--- a/backend/logout.php
+++ b/backend/logout.php
@@ -1,15 +1,10 @@
 <?php
-ini_set('session.cookie_path', '/'); // hilft, falls Pfad-Probleme auftreten
+ini_set('session.cookie_path', '/');
 session_start();
-// backend/logout.php
-session_start(); // Resume the session
 
-// Unset all session variables
-$_SESSION = array();
-
-// Destroy the session
+$_SESSION = [];
 session_destroy();
 
-// Send a success message back
-echo "Logout successful.";
+header('Content-Type: application/json');
+echo json_encode(['status' => 'success']);
 ?>

--- a/backend/mark_submission_processed.php
+++ b/backend/mark_submission_processed.php
@@ -10,7 +10,8 @@ if (!in_array($role, ['gm','admin'])) { http_response_code(403); exit; }
 
 require_once __DIR__ . '/../backend/db_connect.php';
 
-$id = (int)($_POST['id'] ?? 0);
+$data = json_decode(file_get_contents('php://input'), true);
+$id = (int)($data['id'] ?? 0);
 if ($id <= 0) { http_response_code(400); echo json_encode(['ok'=>false]); exit; }
 
 $stmt = $pdo->prepare("UPDATE initiative_submissions SET processed = 1 WHERE id = ?");

--- a/backend/register.php
+++ b/backend/register.php
@@ -1,46 +1,33 @@
 <?php
-ini_set('session.cookie_path', '/'); // hilft, falls Pfad-Probleme auftreten
+ini_set('session.cookie_path', '/');
 session_start();
-// backend/register.php
 
-// 1. Include the database connection
-include 'db_connect.php';
+require_once __DIR__ . '/db_connect.php';
 
-// 2. Get the data from the POST request sent by the JavaScript
-$username = $_POST['username'];
-$password = $_POST['password'];
+header('Content-Type: application/json');
 
-// 3. Basic Validation: Check if inputs are empty
-if (empty($username) || empty($password)) {
-    // Stop the script and send an error message back
-    die("Error: Username and password are required.");
+$username = $_POST['username'] ?? '';
+$password = $_POST['password'] ?? '';
+
+if ($username === '' || $password === '') {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Username and password are required']);
+    exit;
 }
 
-// 4. Securely hash the password
-// password_hash() is the standard, secure way to store passwords.
 $password_hash = password_hash($password, PASSWORD_DEFAULT);
 
-// 5. Use a Prepared Statement to safely insert the new user into the database
-// This prevents SQL injection attacks.
-$stmt = $conn->prepare("INSERT INTO users (username, password_hash) VALUES (?, ?)");
-
-// 'ss' means we are binding two strings to the query
-$stmt->bind_param("ss", $username, $password_hash);
-
-// 6. Execute the statement and provide feedback
-if ($stmt->execute()) {
-    echo "Registration successful!";
-} else {
-    // Check if the error is a 'duplicate entry' error (error number 1062)
-    if ($conn->errno == 1062) {
-        echo "Error: This username is already taken.";
+try {
+    $stmt = $pdo->prepare('INSERT INTO users (username, password_hash) VALUES (?, ?)');
+    $stmt->execute([$username, $password_hash]);
+    echo json_encode(['status' => 'ok']);
+} catch (PDOException $e) {
+    if ($e->getCode() == 23000) {
+        http_response_code(409);
+        echo json_encode(['status' => 'error', 'message' => 'Username already taken']);
     } else {
-        // For other errors, show a generic message
-        echo "Error: An error occurred during registration.";
+        http_response_code(500);
+        echo json_encode(['status' => 'error', 'message' => 'Registration failed']);
     }
 }
-
-// 7. Close the statement and the connection
-$stmt->close();
-$conn->close();
 ?>

--- a/calendar/db_connection.php
+++ b/calendar/db_connection.php
@@ -1,8 +1,8 @@
 <?php
-$host = 'ht7m.your-database.de';
-$db   = 'initiative_tracker';
-$user = 'jerome_tracker';
-$pass = 'h6akkvAgUC33Px3q';
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'initiative_tracker';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
 $charset = 'utf8mb4';
 
 $dsn = "mysql:host=$host;dbname=$db;charset=$charset";

--- a/config/config.php
+++ b/config/config.php
@@ -1,8 +1,8 @@
 <?php
-$servername = "localhost";
-$username = "root";
-$password = ""; // XAMPP/WAMP: Standard ist leer
-$dbname = "dnd_database";
+$servername = getenv('DB_HOST') ?: 'localhost';
+$username = getenv('DB_USER') ?: 'root';
+$password = getenv('DB_PASS') ?: '';
+$dbname = getenv('DB_NAME') ?: 'dnd_database';
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
       <!-- Form to Add New Characters/Monsters -->
       <div class="form-container">
-        <form id="add-character-form">
+        <form id="initiative-form">
           <div class="form-group">
             <label for="name">Name:</label>
             <input
@@ -52,7 +52,7 @@
       </div>
 
       <!-- The list where characters will be displayed -->
-      <ul id="character-list" class="character-list">
+      <ul id="initiative-list" class="character-list">
         <!-- Characters will be dynamically inserted here by JavaScript -->
       </ul>
 
@@ -104,5 +104,6 @@
 
     <!-- Link to your restructured main JavaScript file -->
     <script src="js/script.js"></script>
+    <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,11 +1,8 @@
 const API_URL = "/initiativeTracker/backend.php"; // Stelle sicher, dass der Pfad korrekt ist
 
 // Holt die Initiative-Liste vom Server
-async function fetchInitiativeList(mode = "session", fight_name = "") {
-  const url =
-    mode === "session"
-      ? `${API_URL}?mode=session`
-      : `${API_URL}?mode=db&fight_name=${fight_name}`;
+async function fetchInitiativeList() {
+  const url = `${API_URL}?mode=session`;
 
   try {
     const response = await fetch(url);
@@ -58,13 +55,17 @@ function renderList(entries) {
 async function addEntry(event) {
   event.preventDefault();
 
+  const hpEl = document.getElementById("hp");
+  const typeEl = document.getElementById("type");
+  const modeEl = document.getElementById("fight_mode");
+  const nameEl = document.getElementById("fight_name");
   const data = {
     name: document.getElementById("name").value,
     initiative: parseInt(document.getElementById("initiative").value),
-    hp: document.getElementById("hp").value,
-    type: document.getElementById("type").value,
-    fight_mode: document.getElementById("fight_mode").value,
-    fight_name: document.getElementById("fight_name").value || null,
+    hp: hpEl ? hpEl.value : null,
+    type: typeEl ? typeEl.value : null,
+    fight_mode: modeEl ? modeEl.value : null,
+    fight_name: nameEl ? nameEl.value || null : null,
   };
 
   try {
@@ -137,8 +138,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   //Live-Update alle 5s
   setInterval(() => {
-    const mode = document.getElementById("fight_mode").value;
-    const fightName = document.getElementById("fight_name").value;
-    fetchInitiativeList(mode, fightName);
+    fetchInitiativeList();
   }, 5000);
 });

--- a/view/index.html
+++ b/view/index.html
@@ -25,8 +25,6 @@
     <footer>
       <p>Designed für das E-Team </p>
     </footer>
-    </script>
     <script src="../script.js"></script>
-
   </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize PDO database connection with environment variables
- fix authentication/session APIs to use JSON responses
- align frontend scripts and forms with combat tracker logic

## Testing
- `php -l backend/db_connect.php`
- `php -l backend.php`
- `php -l backend/login.php`
- `php -l backend/get_user_data.php`
- `php -l backend/register.php`
- `php -l backend/logout.php`
- `php -l backend/check_sessions.php`
- `php -l backend/mark_submission_processed.php`
- `php -l users.php`
- `php -l calendar/db_connection.php`
- `php -l config/config.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb294abf28832484b90cd326c8f498